### PR TITLE
performance improvement for CPUs with slow unaligned 64-bit copy

### DIFF
--- a/snappy.c
+++ b/snappy.c
@@ -81,7 +81,7 @@ static inline void unaligned_copy64(char* op, const char* src)
 	UNALIGNED_STORE32(op, UNALIGNED_LOAD32(src));
 	UNALIGNED_STORE32(op + 4, UNALIGNED_LOAD32(src + 4));
 #else
-	UNALIGNED_STORE64(op, UNALIGNED_LOAD32(src));
+	UNALIGNED_STORE64(op, UNALIGNED_LOAD64(src));
 #endif
 }
 


### PR DESCRIPTION
On ARM (and probably other platforms) unaligned 64-bit access is really
slow. Instead of using 'STORE64(p, LOAD64(src))' macro, it is better to
have special function for that.

Logic was copied from original snappy implementation.

Test results for ARM Nova A9500:

Old version:

```
        snappy-c, 0,     786507,     3.2551,     1.2583
        snappy-c, 1,      36915,     4.6512,    13.9788
        snappy-c, 2,      56898,    15.4230,   113.3201
        snappy-c, 3,      62621,    15.8439,   111.8671
        snappy-c, 4,      54598,    12.5148,   104.7013
```

unaligned_copy64:

```
        snappy-c, 0,     786507,     3.1400,     1.2359
        snappy-c, 1,      36915,     2.9551,     2.6206
        snappy-c, 2,      56898,     4.1648,     4.1232
        snappy-c, 3,      62621,     4.3992,     4.1195
        snappy-c, 4,      54598,     4.2060,     4.0001
```

As you see, almost 30x speed improvement in decompression.

P.S. "Original" snappy implementation use similar approach. But they check pointer size to make decision how data will be copied. This hammers performance on Intel 32-bit platforms, where unaligned 64-bit data transfer is pretty fast.
