### PR TITLE
Print format specifier for size_t fixed

### DIFF
--- a/sgverify.c
+++ b/sgverify.c
@@ -177,7 +177,7 @@ int main(int ac, char **av)
 				printf("uncompression of %s failed: %s\n", *av, strerror(-err));
 		
 			if (memcmp(obuf, map, st_size)) {
-				printf("comparison of %s failed, olen %lu, orig %lu, rnd_seq %d\n", *av,
+				printf("comparison of %s failed, olen %zu, orig %zu, rnd_seq %d\n", *av,
 				       outlen, st_size, rnd_seq_start);
 				print_mismatch(obuf, map, st_size);
 			}


### PR DESCRIPTION
Since size_t varies for different architectures, the architecture neutral format specifier to use is %z as proposed in C99 {7.19.6.1 (7)}.
