### PR TITLE
[RFC] Fix UB due to unaligned store/load (corrupted decompress with -ftree-loop-vectorize in gcc10)

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -47,55 +47,10 @@ struct iovec {
 		typeof((v)) _v = (v); \
 		memcpy((x), &_v, sizeof(*(x))); })
 
-#define get_unaligned_direct(x) (*(x))
-#define put_unaligned_direct(v,x) (*(x) = (v))
-
-// Potentially unaligned loads and stores.
-// x86 and PowerPC can simply do these loads and stores native.
-#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc__)
-
-#define get_unaligned get_unaligned_direct
-#define put_unaligned put_unaligned_direct
-#define get_unaligned64 get_unaligned_direct
-#define put_unaligned64 put_unaligned_direct
-
-// ARMv7 and newer support native unaligned accesses, but only of 16-bit
-// and 32-bit values (not 64-bit); older versions either raise a fatal signal,
-// do an unaligned read and rotate the words around a bit, or do the reads very
-// slowly (trip through kernel mode). There's no simple #define that says just
-// “ARMv7 or higher”, so we have to filter away all ARMv5 and ARMv6
-// sub-architectures.
-//
-// This is a mess, but there's not much we can do about it.
-#elif defined(__arm__) && \
-	!defined(__ARM_ARCH_4__) &&		\
-	!defined(__ARM_ARCH_4T__) &&		\
-	!defined(__ARM_ARCH_5__) &&		\
-	!defined(__ARM_ARCH_5T__) &&		\
-	!defined(__ARM_ARCH_5TE__) &&		\
-	!defined(__ARM_ARCH_5TEJ__) &&		\
-	!defined(__ARM_ARCH_6__) &&		\
-	!defined(__ARM_ARCH_6J__) &&		\
-	!defined(__ARM_ARCH_6K__) &&		\
-	!defined(__ARM_ARCH_6Z__) &&		\
-	!defined(__ARM_ARCH_6ZK__) &&		\
-	!defined(__ARM_ARCH_6T2__)
-
-#define get_unaligned get_unaligned_direct
-#define put_unaligned put_unaligned_direct
-#define get_unaligned64 get_unaligned_memcpy
-#define put_unaligned64 put_unaligned_memcpy
-
-// These macroses are provided for architectures that don't support
-// unaligned loads and stores.
-#else
-
 #define get_unaligned get_unaligned_memcpy
 #define put_unaligned put_unaligned_memcpy
 #define get_unaligned64 get_unaligned_memcpy
 #define put_unaligned64 put_unaligned_memcpy
-
-#endif
 
 #define get_unaligned_le32(x) (le32toh(get_unaligned((u32 *)(x))))
 #define put_unaligned_le16(v,x) (put_unaligned(htole16(v), (u16 *)(x)))


### PR DESCRIPTION
Consider the following example:

    $ gcc --version |& fgrep gcc
    gcc (GCC) 10.2.0
    $ yes foobarbaz | fold -w 80 | head -n10 >| in-…
    $ make clean && make CFLAGS='-Wall -g -O2 -ftree-loop-vectorize -DNDEBUG=1 -DSG=1 -fPIC'
    $ ./verify in
    final comparision of in failed at 20 of 100

And UBSAN reports:

    $ make clean && make LDFLAGS=-fsanitize=undefined CFLAGS='-Wall -g -fsanitize=undefined -O2 -ftree-loop-vectorize -DNDEBUG=1 -DSG=1 -fPIC'
    $ ./verify in
    snappy.c:508:9: runtime error: load of misaligned address 0x7ffff7fc9001 for type 'u32', which requires 4 byte alignment
    0x7ffff7fc9001: note: pointer points here
     00 00 00  66 6f 6f 62 61 72 62 61  7a 0a 66 6f 6f 62 61 72  62 61 7a 0a 66 6f 6f 62  61 72 62 61 7a
                  ^
        0 0x55555555eef7 in hash /src/oss/snappy-c/snappy.c:508
        1 0x55555555eef7 in compress_fragment /src/oss/snappy-c/snappy.c:876
        2 0x55555555eef7 in compress /src/oss/snappy-c/snappy.c:1366
        3 0x55555555eef7 in snappy_compress_iov /src/oss/snappy-c/snappy.c:1399
        4 0x555555560116 in snappy_compress /src/oss/snappy-c/snappy.c:1440
        5 0x55555555a998 in main /src/oss/snappy-c/verify.c:37
        6 0x7ffff748f151 in __libc_start_main (/usr/lib/libc.so.6+0x28151)
        7 0x55555555adad in _start (/src/oss/snappy-c/verify+0x6dad)

    ... and lots of other places, snipped ...

In incremental_copy_fast_path there is undefined behavior (and in some
other places too).
And under this circumstances gcc10 with -O1 -ftree-loop-vectorize (or
simply -O3), due to loop unroll, generates code that do copy by 16 bytes
at a time for the second loop (MOVDQU+MOVUPS), while this is not correct
since the memory may be overlapped and may be changed in the previous
iteration.

Fix this by eliminating those UB, by using memcpy over direct store/load
since these days direct store/loads looks redundant. Even on ARM [1].

  [1]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=67366

Also here is asm for hash() function, just to underline that the code is
the same.

Before this patch:

    Dump of assembler code for function hash:
       0x0000000000001440 <+0>:     imul   eax,DWORD PTR [rdi],0x1e35a7bd
       0x0000000000001446 <+6>:     mov    ecx,esi
       0x0000000000001448 <+8>:     shr    eax,cl
       0x000000000000144a <+10>:    ret

After this patch:

    Dump of assembler code for function hash:
       0x0000000000001440 <+0>:     imul   eax,DWORD PTR [rdi],0x1e35a7bd
       0x0000000000001446 <+6>:     mov    ecx,esi
       0x0000000000001448 <+8>:     shr    eax,cl
       0x000000000000144a <+10>:    ret

*Marked as RFC, since at least __KERNEL__ code leaved as-is for now and to get some comments on the patch*

*P.S. sorry for the references storm*

*NOTE: clang is fine, and other older versions of gcc too*

This bug was found by [ClickHouse](https://github.com/ClickHouse/ClickHouse) test suite.