### PR TITLE
Fix unused variable warning

### DIFF
--- a/snappy.c
+++ b/snappy.c
@@ -1303,13 +1303,11 @@ static inline int compress(struct snappy_env *env, struct source *reader,
 			   struct sink *writer)
 {
 	int err;
-	size_t written = 0;
 	int N = available(reader);
 	char ulength[kmax32];
 	char *p = varint_encode32(ulength, N);
 
 	append(writer, ulength, p - ulength);
-	written += (p - ulength);
 
 	while (N > 0) {
 		/* Get next block to compress (without copying if possible) */
@@ -1366,7 +1364,6 @@ static inline int compress(struct snappy_env *env, struct source *reader,
 		char *end = compress_fragment(fragment, fragment_size,
 					      dest, table, table_size);
 		append(writer, dest, end - dest);
-		written += (end - dest);
 
 		N -= num_to_read;
 		skip(reader, pending_advance);


### PR DESCRIPTION
Fixes unused variable warning:
```
    snappy-c/snappy.c:1306:9: error: variable 'written' set but not used [-Werror,-Wunused-but-set-variable]
            size_t written = 0;
                   ^
```